### PR TITLE
AutoCompleteInputDecorator RegEx escaping (plus 1 other)

### DIFF
--- a/source/controls/Accordion.js
+++ b/source/controls/Accordion.js
@@ -82,7 +82,7 @@ enyo.kind({
 				headerHeights += c.getHeaderHeight();
 				
 				// find default section
-				if(defaultSection === null && c.defaultSection === true) {
+				if((defaultSection === null || defaultSection === undefined) && c.defaultSection === true) {
 					defaultSection = c;
 				}
 			});

--- a/source/controls/AutoCompleteInputDecorator.js
+++ b/source/controls/AutoCompleteInputDecorator.js
@@ -78,8 +78,11 @@ enyo.kind({
             return String(input).toLowerCase() == String(value).toLowerCase();
         }
     },
+    escapeRegExp:function(str) {
+      return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+    },
     filter:function(input, value) {
-        return new RegExp(input, this.caseSensitive ? "g" : "ig").test(value);
+        return new RegExp(this.escapeRegExp(input), this.caseSensitive ? "g" : "ig").test(value);
     },
     itemSelected: function(source, event) {
         this.log("selected");


### PR DESCRIPTION
Allow AutoCompleteInputDecorator to behave properly with strings that otherwise need escaped before being used as a RegEx.

Also a small tweak to Accordion to fix a bug I encountered.
